### PR TITLE
Add padStart formatting function

### DIFF
--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -349,6 +349,11 @@ describe('computeTraceLink()', () => {
       url: 'http://example.com/?traceID=#{traceID}&traceName=#{traceName}&startTime=#{startTime}&endTime=#{endTime}&duration=#{duration}',
       text: 'third link (#{traceID}, #{traceName}, #{startTime}, #{endTime}, #{duration})',
     },
+    {
+      type: 'traces',
+      url: 'http://example.com/?startTime=#{startTime | epoch_micros_to_date_iso}&endTime=#{endTime | epoch_micros_to_date_iso}',
+      text: 'third link (#{startTime | epoch_micros_to_date_iso}, #{endTime | epoch_micros_to_date_iso})',
+    },
   ].map(processLinkPattern);
 
   const trace = {
@@ -357,7 +362,7 @@ describe('computeTraceLink()', () => {
     traceID: 'trc1',
     spans: [],
     startTime: 1000,
-    endTime: 3000,
+    endTime: 3000000000000,
     duration: 2000,
     services: [],
   };
@@ -369,8 +374,12 @@ describe('computeTraceLink()', () => {
         text: 'first link (trc1)',
       },
       {
-        url: 'http://example.com/?traceID=trc1&traceName=theTrace&startTime=1000&endTime=3000&duration=2000',
-        text: 'third link (trc1, theTrace, 1000, 3000, 2000)',
+        url: 'http://example.com/?traceID=trc1&traceName=theTrace&startTime=1000&endTime=3000000000000&duration=2000',
+        text: 'third link (trc1, theTrace, 1000, 3000000000000, 2000)',
+      },
+      {
+        text: 'third link (1970-01-01T00:00:00.001Z, 1970-02-04T17:20:00.000Z)',
+        url: 'http://example.com/?startTime=1970-01-01T00%3A00%3A00.001Z&endTime=1970-02-04T17%3A20%3A00.000Z',
       },
     ]);
   });

--- a/packages/jaeger-ui/src/utils/link-formatting.test.js
+++ b/packages/jaeger-ui/src/utils/link-formatting.test.js
@@ -15,16 +15,45 @@
 import { getParameterAndFormatter } from './link-formatting';
 
 describe('getParameterAndFormatter()', () => {
-  test('epoch_micros_to_date_iso', () => {
-    const result = getParameterAndFormatter('startTime | epoch_micros_to_date_iso');
-    expect(result).toEqual({
-      parameterName: 'startTime',
-      formatFunction: expect.any(Function),
+  describe('epoch_micros_to_date_iso', () => {
+    test('epoch_micros_to_date_iso', () => {
+      const result = getParameterAndFormatter('startTime | epoch_micros_to_date_iso');
+      expect(result).toEqual({
+        parameterName: 'startTime',
+        formatFunction: expect.any(Function),
+      });
+
+      expect(result.formatFunction(new Date('2020-01-01').getTime() * 1000)).toEqual(
+        '2020-01-01T00:00:00.000Z'
+      );
     });
 
-    expect(result.formatFunction(new Date('2020-01-01').getTime() * 1000)).toEqual(
-      '2020-01-01T00:00:00.000Z'
-    );
+    test('Non date', () => {
+      const result = getParameterAndFormatter('startTime | epoch_micros_to_date_iso');
+      expect(result.formatFunction('Not a date value')).toEqual('Not a date value');
+    });
+  });
+
+  describe('pad_start', () => {
+    test('Valid desired length', () => {
+      const result = getParameterAndFormatter('traceID | pad_start 10 0');
+      expect(result).toEqual({
+        parameterName: 'traceID',
+        formatFunction: expect.any(Function),
+      });
+
+      expect(result.formatFunction('12345')).toEqual('0000012345');
+    });
+
+    test('Invalid desired length', () => {
+      const result = getParameterAndFormatter('traceID | pad_start invalid 0');
+      expect(result.formatFunction('12345')).toEqual('12345');
+    });
+
+    test('Invalid input', () => {
+      const result = getParameterAndFormatter('traceID | pad_start 32 0');
+      expect(result.formatFunction(12345)).toEqual(12345);
+    });
   });
 
   test('No function', () => {

--- a/packages/jaeger-ui/src/utils/link-formatting.test.js
+++ b/packages/jaeger-ui/src/utils/link-formatting.test.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getParameterAndFormatter } from './link-formatting';
+
+describe('getParameterAndFormatter()', () => {
+  test('epoch_micros_to_date_iso', () => {
+    const result = getParameterAndFormatter('startTime | epoch_micros_to_date_iso');
+    expect(result).toEqual({
+      parameterName: 'startTime',
+      formatFunction: expect.any(Function),
+    });
+
+    expect(result.formatFunction(new Date('2020-01-01').getTime() * 1000)).toEqual(
+      '2020-01-01T00:00:00.000Z'
+    );
+  });
+
+  test('No function', () => {
+    const result = getParameterAndFormatter('startTime');
+    expect(result).toEqual({
+      parameterName: 'startTime',
+      formatFunction: null,
+    });
+  });
+
+  test('Invalid function', () => {
+    const result = getParameterAndFormatter('startTime | invalid');
+    expect(result).toEqual({
+      parameterName: 'startTime',
+      formatFunction: null,
+    });
+  });
+});

--- a/packages/jaeger-ui/src/utils/link-formatting.tsx
+++ b/packages/jaeger-ui/src/utils/link-formatting.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Trace } from '../types/trace';
+
+function getFormatFunctions<T = Trace[keyof Trace]>(): Record<string, (value: T) => string | T> {
+  return {
+    epoch_micros_to_date_iso: microsSinceEpoch => {
+      if (typeof microsSinceEpoch !== 'number') {
+        console.error('epoch_micros_to_date_iso can only operate on numbers, ignoring formatting', {
+          value: microsSinceEpoch,
+        });
+        return microsSinceEpoch;
+      }
+
+      return new Date(microsSinceEpoch / 1000).toISOString();
+    },
+  };
+}
+
+export function getParameterAndFormatter<T = Trace[keyof Trace]>(
+  parameter: string
+): {
+  parameterName: string;
+  formatFunction: ((value: T) => T | string) | null;
+} {
+  const [parameterName, formatFunctionName] = parameter.split('|').map(part => part.trim());
+  if (!formatFunctionName) return { parameterName, formatFunction: null };
+  const formatFunctions = getFormatFunctions<T>();
+
+  const formatFunction = formatFunctions[formatFunctionName];
+  if (!formatFunction) {
+    console.error('Unrecognized format function name, ignoring formatting', {
+      parameter,
+      formatFunctionName,
+      validValues: Object.keys(formatFunctions),
+    });
+  }
+
+  return { parameterName, formatFunction: formatFunction ?? null };
+}

--- a/packages/jaeger-ui/src/utils/link-formatting.tsx
+++ b/packages/jaeger-ui/src/utils/link-formatting.tsx
@@ -14,7 +14,10 @@
 
 import { Trace } from '../types/trace';
 
-function getFormatFunctions<T = Trace[keyof Trace]>(): Record<string, (value: T) => string | T> {
+function getFormatFunctions<T = Trace[keyof Trace]>(): Record<
+  string,
+  (value: T, ...args: string[]) => string | T
+> {
   return {
     epoch_micros_to_date_iso: microsSinceEpoch => {
       if (typeof microsSinceEpoch !== 'number') {
@@ -26,6 +29,26 @@ function getFormatFunctions<T = Trace[keyof Trace]>(): Record<string, (value: T)
 
       return new Date(microsSinceEpoch / 1000).toISOString();
     },
+    pad_start: (value, desiredLengthString: string, padCharacter: string) => {
+      if (typeof value !== 'string') {
+        console.error('pad_start can only operate on strings, ignoring formatting', {
+          value,
+          desiredLength: desiredLengthString,
+          padCharacter,
+        });
+        return value;
+      }
+      const desiredLength = parseInt(desiredLengthString, 10);
+      if (Number.isNaN(desiredLength)) {
+        console.error('pad_start needs a desired length as second argument, ignoring formatting', {
+          value,
+          desiredLength: desiredLengthString,
+          padCharacter,
+        });
+      }
+
+      return value.padStart(desiredLength, padCharacter);
+    },
   };
 }
 
@@ -35,8 +58,12 @@ export function getParameterAndFormatter<T = Trace[keyof Trace]>(
   parameterName: string;
   formatFunction: ((value: T) => T | string) | null;
 } {
-  const [parameterName, formatFunctionName] = parameter.split('|').map(part => part.trim());
-  if (!formatFunctionName) return { parameterName, formatFunction: null };
+  const parts = parameter.split('|').map(part => part.trim());
+  const parameterName = parts[0];
+  if (parts.length === 1) return { parameterName, formatFunction: null };
+
+  const [formatFunctionName, ...args] = parts[1].split(' ');
+
   const formatFunctions = getFormatFunctions<T>();
 
   const formatFunction = formatFunctions[formatFunctionName];
@@ -48,5 +75,5 @@ export function getParameterAndFormatter<T = Trace[keyof Trace]>(
     });
   }
 
-  return { parameterName, formatFunction: formatFunction ?? null };
+  return { parameterName, formatFunction: formatFunction ? val => formatFunction(val, ...args) : null };
 }

--- a/packages/jaeger-ui/src/utils/stringSupplant.tsx
+++ b/packages/jaeger-ui/src/utils/stringSupplant.tsx
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { getParameterAndFormatter } from './link-formatting';
+
 const PARAMETER_REG_EXP = /#\{([^{}]*)\}/g;
 
 export function encodedStringSupplant(
@@ -20,8 +22,11 @@ export function encodedStringSupplant(
   map: Record<string, string | number | undefined>
 ) {
   return str.replace(PARAMETER_REG_EXP, (_, name) => {
-    const mapValue = map[name];
-    const value = mapValue != null && encodeFn ? encodeFn(mapValue) : mapValue;
+    const { parameterName, formatFunction } = getParameterAndFormatter<string | number | undefined>(name);
+    const mapValue = map[parameterName];
+    const formattedValue = formatFunction && mapValue ? formatFunction(mapValue) : mapValue;
+
+    const value = formattedValue != null && encodeFn ? encodeFn(formattedValue) : mapValue;
     return value == null ? '' : `${value}`;
   });
 }


### PR DESCRIPTION
Given a traceparent header like `00-00000000000000001b3ef83a5d15ed1b-61409d351b3a5d99-01`, jaeger will store (and thus display + interpolate) the trace ID as `1b3ef83a5d15ed1b`. When attempting to use the shortened trace ID to link to logs some tracing integrations (in my case, logs using [pino](https://www.npmjs.com/package/pino) instrumented with the [OpenTelemetry pino instrumentation](https://www.npmjs.com/package/@opentelemetry/instrumentation-pino)) will use the full length trace ID, making jaeger link patterns not work.

This PR adds a `padStart` formatting function, heavily inspired by javascript's [String.padStart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart) to format the trace ID in those cases. If approved, I'll update the documentation in https://github.com/jaegertracing/documentation to mention this function and it's behavior.

In addition to this specific function, I'd like feedback on the approach of passing arguments to formatting functions with the space-delimited approach (eg `#{traceID | padStart 32 0}`).